### PR TITLE
Bug Fix - Build devDependencie - redux-devtools-extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@reduxjs/toolkit": "^1.3.4",
-    "node-sass": "^4.13.1"
+    "node-sass": "^4.13.1",
+    "redux-devtools-extension": "^2.13.8"
   }
 }


### PR DESCRIPTION
Sample pull request: 
Without `redux-devtools-extension` , `yarn start` will fail